### PR TITLE
Fixed playbook run copy command and typo

### DIFF
--- a/exercises/ansible_rhel/cicd-tower-api/README.md
+++ b/exercises/ansible_rhel/cicd-tower-api/README.md
@@ -2,9 +2,9 @@
 
 We are going to use our Install Apache example again but integrate it with our CI/CD pipeline to automatically deploy our website.
 
-## Create gitlab repository
+## Create a gitlab repository
 
-Select **Create Project**
+Select **Create a Project**
 
 ![gitlab-create-project](gitlab-create-project.png)
 
@@ -12,7 +12,7 @@ Name the project **apache** and make sure the repository is set to **public**
 
 ![gitlab-create-project-details](gitlab-create-project-details.png)
 
-Finally, click **clone** and then copy the **Clone with HTTPS** by clicking on the clipboard icon next to **Clone with HTTPS**.
+Finally, click **Clone** and then copy the **Clone with HTTPS** by clicking on the clipboard icon next to **Clone with HTTPS**.
 
 ![gitlab-clone-repo-link](gitlab-clone-repo-link.png)
 
@@ -23,6 +23,11 @@ As your student user, log onto ansible-1 and clone the repo
 ```bash
 cd ~
 git clone https://gitlab.533b.example.opentlc.com/student10/apache.git
+```
+
+Output:
+
+```bash
 Cloning into 'apache'...
 warning: You appear to have cloned an empty repository.
 ```
@@ -91,7 +96,7 @@ If you check the gitlab repository in your web browser, you should now see your 
 
 ![gitlab-push](gitlab-push.png)
 
-## Create playbook to configure Ansible Tower
+## Create a playbook to configure Ansible Tower
 
 Now that we have our playbook, we are going to write a second playbook that will create the necessary objects in Ansible Tower to allow us to execute our job. As the student user on the ansible-1 create a directory for the Tower configuration:
 

--- a/exercises/ansible_rhel/tower-modules-tower-api/README.md
+++ b/exercises/ansible_rhel/tower-modules-tower-api/README.md
@@ -72,7 +72,11 @@ Now let's launch our job:
 
 ```bash
 ansible-playbook tower_job_launch.yml 
+```
 
+The output should look like this:
+
+```bash
 PLAY [launch a tower job] ********************************************************************************************************************************************************************
 
 TASK [launch Install Apache job] *************************************************************************************************************************************************************
@@ -89,7 +93,7 @@ You can check in the Tower UI to validate if your job ran successfully.
 
 ## Summary
 
-We have now looked at four different ways of interacting with Ansible Tower todo the same thing - launch a job. The UI, directly with the API, Tower CLI and finally the Ansible Tower modules. This gives users the flexibility to consume the Ansible Automation Platform in the way that best suits their use-case. In the next lab we are going to look at a more complete example and how we can configure larger parts of Ansible Tower with the Ansible modules.
+We have now looked at four different ways of interacting with Ansible Tower to do the same thing - launch a job. The UI, directly with the API, Tower CLI and finally the Ansible Tower modules. This gives users the flexibility to consume the Ansible Automation Platform in the way that best suits their use-case. In the next lab we are going to look at a more complete example and how we can configure larger parts of Ansible Tower with the Ansible modules.
 
 ---
 


### PR DESCRIPTION
Wasn't sure how to leave the output so it's not something a user would necessarily copy so just used the same method as you have used throughout the docs.